### PR TITLE
Better check if the key is 'create'

### DIFF
--- a/gtoesd
+++ b/gtoesd
@@ -270,11 +270,12 @@ class gmeta_processor:
                 #
                 c = 0
                 for i in rdata['items']:
-                    if i['create']['status'] != 201:
-                        logging.debug('index error source: %s, message: %s' %(
-                            self.buffer[c*2+1],i
-                        ))
-                    c+=1
+                    if 'create' in i:
+                        if i['create']['status'] != 201:
+                            logging.debug('index error source: %s, message: %s' %(
+                                self.buffer[c*2+1],i
+                            ))
+                        c+=1
         else:
             logging.error('Got bad return from es: %d %s' %(
                 res.status, res.reason


### PR DESCRIPTION
```
gtoesd[11796]: Traceback (most recent call last):
gtoesd[11796]: File "/usr/bin/gtoesd", line 629, in <module>
gtoesd[11796]: g.run()
gtoesd[11796]: File "/usr/bin/gtoesd", line 537, in run
gtoesd[11796]: self.parse_metrics()
gtoesd[11796]: File "/usr/bin/gtoesd", line 370, in parse_metrics
gtoesd[11796]: if self.elastic_index():
gtoesd[11796]: File "/usr/bin/gtoesd", line 273, in elastic_index
gtoesd[11796]: if i['create']['status'] != 201:
gtoesd[11796]: KeyError: 'create'
```